### PR TITLE
composer インストール手順修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ yum install --enablerepo=remi,remi-php74 php php-pdo php-mbstring php-dom php-
 * composer
 ```bash
 $ php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-$ php -r "if (hash_file('sha384', 'composer-setup.php') === 'e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+$ php -r "if (hash_file('sha384', 'composer-setup.php') === file_get_contents('https://composer.github.io/installer.sig')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 $ php composer-setup.php
 $ php -r "unlink('composer-setup.php');"
 # Globallyにcomposerを利用するために/usr/local/bin/に移動させる


### PR DESCRIPTION
ファイルハッシュが直書きされているため､ Composer がアップデート等した際に､以下のコマンドは実行できなくなります
※ [Composer の公式ドキュメントにも注意書きあり](https://getcomposer.org/download/)あり

```bash
$ php -r "if (hash_file('sha384', 'composer-setup.php') === 'e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
```

その改善のため､ README 記載の Composer インストールコマンドをファイルハッシュ値に依存しないものに修正しました