### PR TITLE
Larastanの追加、型の不整合の修正

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
+use Illuminate\View\View;
 use SimpleSoftwareIO\QrCode\Facades\QrCode;
 
 class GroupController extends Controller
@@ -17,9 +18,8 @@ class GroupController extends Controller
     /**
      * グループの情報を表示。
      *
-     * @param $hash
-     * グループのハッシュ。
-     * @return Response
+     * @param string $hash グループのハッシュ。
+     * @return View
      */
     public function show($hash)
     {
@@ -32,7 +32,7 @@ class GroupController extends Controller
     /**
      * 新しいグループの登録フォームを表示。
      *
-     * @return Response
+     * @return View
      */
     public function create()
     {
@@ -43,7 +43,7 @@ class GroupController extends Controller
      * 新しいグループを登録。
      *
      * @param Request $request
-     * @return Response
+     * @return View
      */
     public function store(Request $request)
     {
@@ -100,8 +100,7 @@ class GroupController extends Controller
     /**
      * ポスター用のPDFを表示。
      *
-     * @param $hash
-     * グループのハッシュ。
+     * @param string $hash グループのハッシュ。
      * @return mixed
      */
     public function poster_pdf($hash)
@@ -125,8 +124,7 @@ class GroupController extends Controller
     /**
      * POP用のPDFを表示。
      *
-     * @param $hash
-     * グループのハッシュ。
+     * @param string $hash グループのハッシュ。
      * @return mixed
      */
     public function pop_pdf($hash)
@@ -150,10 +148,8 @@ class GroupController extends Controller
     /**
      * PNG画像を表示。
      *
-     * @param $size
-     * 画像の一辺の大きさ。
-     * @param $hash
-     * グループのハッシュ。
+     * @param int $size 画像の一辺の大きさ。
+     * @param string $hash グループのハッシュ。
      * @return mixed
      */
     public function png($size, $hash)

--- a/app/Http/Controllers/RecipientController.php
+++ b/app/Http/Controllers/RecipientController.php
@@ -20,15 +20,14 @@ use Throwable;
 class RecipientController extends Controller
 {
     /**
-     * @var
-     * 受信者
+     * @var Recipient 受信者
      */
     private $recipient;
 
     /**
      * メールアドレス登録画面の表示
      *
-     * @param $hash
+     * @param string $hash
      * @return Application|Factory|RedirectResponse|Redirector|View
      * @throws \Exception
      */
@@ -89,7 +88,7 @@ class RecipientController extends Controller
     /**
      * メールアドレス登録解除画面の表示
      *
-     * @param $hash
+     * @param string $hash
      * @param Request $request
      * @return Application|Factory|RedirectResponse|Redirector|View
      */

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -17,5 +17,7 @@ class Authenticate extends Middleware
         if (! $request->expectsJson()) {
             return route('login');
         }
+
+        return null;
     }
 }

--- a/app/Mail/GroupRegistered.php
+++ b/app/Mail/GroupRegistered.php
@@ -12,12 +12,13 @@ class GroupRegistered extends Mailable
 {
     use Queueable, SerializesModels;
 
+    /** @var array<string,mixed> */
     protected $mail_data;
 
     /**
      * Create a new message instance.
      *
-     * @param $mail_data
+     * @param array<string,mixed> $mail_data
      */
     public function __construct($mail_data)
     {

--- a/app/Mail/RecipientRegister.php
+++ b/app/Mail/RecipientRegister.php
@@ -12,12 +12,13 @@ class RecipientRegister extends Mailable
 {
     use Queueable, SerializesModels;
 
+    /** @var array<string,mixed> */
     protected $mail_data;
 
     /**
      * Create a new message instance.
      *
-     * @param $mail_data
+     * @param array<string,mixed> $mail_data
      */
     public function __construct($mail_data)
     {

--- a/app/Rules/EmailExists.php
+++ b/app/Rules/EmailExists.php
@@ -7,14 +7,16 @@ use Illuminate\Contracts\Validation\Rule;
 
 class EmailExists implements Rule
 {
+    /** @var string */
     private $email;
+    /** @var string */
     private $group_id;
 
     /**
      * Create a new rule instance.
      *
-     * @param $email
-     * @param $group_id
+     * @param string $email
+     * @param string $group_id
      */
     public function __construct($email, $group_id)
     {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "laravel/dusk": "^6.2",
         "mockery/mockery": "^1.3.1",
         "nunomaduro/collision": "^4.1",
+        "nunomaduro/larastan": "^0.6.1",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "phpunit/phpunit": "^8.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ece2bd92a1833a791357d9a2348c00d",
+    "content-hash": "59417b22963732605548b2574825d255",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5163,6 +5163,99 @@
             "time": "2020-04-04T19:56:08+00:00"
         },
         {
+            "name": "nunomaduro/larastan",
+            "version": "v0.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/larastan.git",
+                "reference": "7e333510eaaed6fc0e670c69fed148320ecb1cac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/7e333510eaaed6fc0e670c69fed148320ecb1cac",
+                "reference": "7e333510eaaed6fc0e670c69fed148320ecb1cac",
+                "shasum": ""
+            },
+            "require": {
+                "composer/composer": "^1.0 || ^2.0",
+                "ext-json": "*",
+                "illuminate/console": "^6.0 || ^7.0 || ^8.0",
+                "illuminate/container": "^6.0 || ^7.0 || ^8.0",
+                "illuminate/contracts": "^6.0 || ^7.0 || ^8.0",
+                "illuminate/database": "^6.0 || ^7.0 || ^8.0",
+                "illuminate/http": "^6.0 || ^7.0 || ^8.0",
+                "illuminate/pipeline": "^6.0 || ^7.0 || ^8.0",
+                "illuminate/support": "^6.0 || ^7.0 || ^8.0",
+                "mockery/mockery": "^0.9 || ^1.0",
+                "php": "^7.2",
+                "phpstan/phpstan": "^0.12.28",
+                "symfony/process": "^4.3 || ^5.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^4.0 || ^5.0",
+                "phpunit/phpunit": "^7.3 || ^8.2"
+            },
+            "suggest": {
+                "orchestra/testbench": "^4.0 || ^5.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.6-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "NunoMaduro\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan wrapper for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-06-20T12:11:51+00:00"
+        },
+        {
             "name": "phar-io/manifest",
             "version": "1.0.3",
             "source": {
@@ -5592,6 +5685,62 @@
                 "stub"
             ],
             "time": "2020-03-05T15:02:03+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "0.12.31",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "776c8056b401e1b67f277b9e9fb334d1a274671d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/776c8056b401e1b67f277b9e9fb334d1a274671d",
+                "reference": "776c8056b401e1b67f277b9e9fb334d1a274671d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.12-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-24T20:55:29+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -6852,5 +7001,6 @@
     "platform": {
         "php": "^7.2.5"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,15 @@
+includes:
+    - ./vendor/nunomaduro/larastan/extension.neon
+
+parameters:
+
+    paths:
+        - app
+
+    # The level 8 is the highest level
+    level: 8
+
+    excludes_analyse:
+        - ./*/*/FileToBeExcluded.php
+
+    checkMissingIterableValueType: false


### PR DESCRIPTION
[PHPStan](https://github.com/phpstan/phpstan)はPHPの静的解析ツールで、[Larastan](https://github.com/nunomaduro/larastan)はLaravelに特化したPHPStanの設定です。

欠けている型定義を追加・修正していますが、基本的にコメントのみの修正なので動作に影響はないはずです。